### PR TITLE
removes host from /shorten response

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ def shorten_url():
     if not original_url:
         return jsonify({"error": "URL is required"}), 400
     result = db.write(original_url)
-    result['host'] = request.host_url # FIXME: returns a http url despite running behind a proxy using TLS
     return jsonify(result)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is redundant as the requester has the host url anyway and can simple add the code to the base url. 